### PR TITLE
edit encryption behavior and associated queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A discord bot for saving and displaying memorable quotes from your friends.
 
 The bot is written in javascript and makes heavy use of [discord.js](https://discord.js.org/#/), which is a wrapper around the Discord API (view the [developer documentation](https://discord.com/developers/docs/intro)).
 
-I currently host the bot using the [Heroku Cloud Platform](https://heroku.com). The bot speaks to a PostgreSQL instance hosted for free on [ElephantSQL](https://www.elephantsql.com/), where I store quotes from the few servers where the bot operates. The bot's connection to the database is SSL-enabled. Quotes, authors, and guild IDs are stored with encryption.
+I currently host the bot using the [Heroku Cloud Platform](https://heroku.com). The bot speaks to a PostgreSQL instance hosted for free on [ElephantSQL](https://www.elephantsql.com/), where I store quotes from the few servers where the bot operates. The bot's connection to the database is SSL-enabled. The "quotation" column is encrypted.
 
 # Running your own instance of the bot
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -10,8 +10,8 @@ CREATE COLLATION ci (
 CREATE TABLE quotes(
     id SERIAL,
     quotation citext NOT NULL,
-    author character varying(260) COLLATE ci NOT NULL,
+    author character varying(64) COLLATE ci NOT NULL,
     said_at date NOT NULL,
-    guild_id character varying(260) NOT NULL,
+    guild_id character varying(64) NOT NULL,
     hash text NOT NULL PRIMARY KEY
 );

--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -108,10 +108,11 @@ module.exports = {
     },
 
     searchHandler: async (interaction) => {
+        await interaction.deferReply();
         const searchString = interaction.options.getString('search_string')?.trim();
         const includeIdentifier = interaction.options.getBoolean('include_identifier');
         const searchResults = await queries.fetchQuotesBySearchString(searchString, interaction.guildId).catch(async (e) => {
-            await interaction.reply({ content: responseMessages.GENERIC_ERROR, ephemeral: true });
+            await interaction.followUp({ content: responseMessages.GENERIC_ERROR, ephemeral: true });
         });
 
         let reply = '';
@@ -128,7 +129,7 @@ module.exports = {
         }
 
         if (!interaction.replied) {
-            await interaction.reply(reply);
+            await interaction.followUp(reply);
         }
     },
 

--- a/modules/response-messages.js
+++ b/modules/response-messages.js
@@ -16,12 +16,13 @@ module.exports = {
     QUERY_TOO_GENERAL: 'Your search returned too many results! Use a narrower search.',
     HELP_MESSAGE: '**About:**\n\nThis is a bot for adding quotes and revisiting them later. Add a quote with `/add`. Find quotes with `/search`.' +
         ' Pull random quotes with `/random`. To delete a quote, you must first search for it with the `include_identifier` ' +
-        'option as `true`. This will return an integer ID for the quote. Then, provide that ID to the `/delete` command.\n\n' +
+        'option as `true`. This will return an integer ID for the quote. Then, provide that ID to the `/delete` command.' +
+        ' You can also generate a "wordcloud" visualization of quotes said in your server using `/wordcloud`.\n\n' +
         '**Privacy Policy:**\n\n' +
         'Quotes added in a particular server can only be retrieved by users in that server. ' +
         'The bot uses an SSL connection to store your quotes in a password-protected database. Only the bot and its ' +
-        'creator have access. Quotes and their authors are stored with encryption. The data is only used for this bot and its ' +
-        'associated commands.\n\n' +
+        'creator have access. Quotes (but not the names of their authors) are stored with encryption. The data is only' +
+        ' used for this bot and its associated commands.\n\n' +
         '**Support:**\n\nFor questions or concerns, you can e-mail the creator at leohfx@gmail.com\n\n' +
         'This bot is open source! Find it at: https://github.com/AlecM33/quote-bot'
 };


### PR DESCRIPTION
We only encrypt the quotation column now. It's the only column that I view as meriting encryption at rest. This also restores the functionality of the case-insensitive collation I have placed on the author column. Long-term this may also benefit query performance by enabling indices on authors or guild IDs. 