### PR TITLE
Conditional authors to file

### DIFF
--- a/commands/authors.js
+++ b/commands/authors.js
@@ -6,6 +6,6 @@ module.exports = {
         .setName('authors')
         .setDescription('Get a sorted list of unique authors of saved quotes.'),
     async execute (interaction, guildManager) {
-        await interactionHandlers.authorsHandler(interaction);
+        await interactionHandlers.authorsHandler(interaction, guildManager);
     }
 };

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -6,14 +6,9 @@ module.exports = {
         2: 'SIZE_MEDIUM',
         3: 'SIZE_LARGE'
     },
-    WORDCLOUD_NUMBER_OF_WORDS_MAP: {
-        1: 25,
-        2: 50,
-        3: 100
-    },
     MAX_WORDCLOUD_WORDS: 300,
     MAX_DISCORD_MESSAGE_LENGTH: 2000,
-    MAX_AUTHOR_LENGTH: 120,
+    MAX_AUTHOR_LENGTH: 240,
     MENTION_REGEX: /<@[&!0-9]+>|<#[0-9]+>/g,
     AUTHOR_SEPARATOR: ' • '
 };

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -6,7 +6,14 @@ module.exports = {
         2: 'SIZE_MEDIUM',
         3: 'SIZE_LARGE'
     },
+    WORDCLOUD_NUMBER_OF_WORDS_MAP: {
+        1: 25,
+        2: 50,
+        3: 100
+    },
     MAX_WORDCLOUD_WORDS: 300,
     MAX_DISCORD_MESSAGE_LENGTH: 2000,
-    MAX_AUTHOR_LENGTH: 120
+    MAX_AUTHOR_LENGTH: 120,
+    MENTION_REGEX: /<@[&!0-9]+>|<#[0-9]+>/g,
+    AUTHOR_SEPARATOR: ' • '
 };

--- a/modules/response-messages.js
+++ b/modules/response-messages.js
@@ -39,7 +39,11 @@ module.exports = {
         '**Support:**\n\nFor questions or concerns, you can e-mail the creator at leohfx@gmail.com. Thanks so much for using my bot! :) ' +
         'I hope it serves as a nice tool to preserve good memories.\n\n' +
         'This bot is open source! Find it at: https://github.com/AlecM33/quote-bot',
-    UPDATES_MESSAGE: '**Latest Updates**\n\n**v1.0.1** (7 November 2023)\n- There is now an optional "date" parameter for' +
-        ' the `/add` command. If a quote was said a while ago, and you want to capture that when saving it with this bot,' +
-        ' provide a date. The bot will say it was added on that day. Otherwise, it will use today\'s date.'
+    UPDATES_MESSAGE: '**Latest Updates**\n\n**v1.0.2** (11 March 2024)\n- Fixed a bug that prevented the `/authors` command ' +
+        'from working if the bot\'s reply would exceed Discord\'s maximum message length. Now, if this would be the case, it will attach ' +
+        'the authors as a file instead. \n\n**1000 quotes!** (28 December 2023)\n- This bot is now storing over 1000 ' +
+        'quotes from several dozen servers. Cheers to the new year and happy quoting!\n\n**v1.0.1** (7 November 2023)\n-' +
+        ' There is now an optional "date" parameter for the `/add` command. If a quote was said a while ago, and you want' +
+        ' to capture that when saving it with this bot, provide a date. The bot will say it was added on that day. Otherwise,' +
+        ' it will use today\'s date.'
 };

--- a/modules/utilities.js
+++ b/modules/utilities.js
@@ -27,7 +27,7 @@ module.exports = {
             quoteMessage = '_' + quoteMessage + '_';
         }
 
-        if (toFile && constants.MENTION_REGEX.test(quote.author)) { // Discord @s are represented as <@UserID>
+        if (toFile && quote.author.match(constants.MENTION_REGEX)) { // Discord @s are represented as <@UserID>
             quoteMessage = quoteMessage + ' - ' + await attemptToResolveMentionsToName(guildManager, interaction, quote.author);
         } else {
             quoteMessage = quoteMessage + ' - ' + quote.author;

--- a/modules/utilities.js
+++ b/modules/utilities.js
@@ -27,8 +27,8 @@ module.exports = {
             quoteMessage = '_' + quoteMessage + '_';
         }
 
-        if (toFile && /^<@[&!0-9]+>|<#[0-9]+>$/.test(quote.author)) { // Discord @s are represented as <@UserID>
-            quoteMessage = quoteMessage + ' - ' + await attemptToResolveMentionToName(guildManager, interaction, quote.author);
+        if (toFile && constants.MENTION_REGEX.test(quote.author)) { // Discord @s are represented as <@UserID>
+            quoteMessage = quoteMessage + ' - ' + await attemptToResolveMentionsToName(guildManager, interaction, quote.author);
         } else {
             quoteMessage = quoteMessage + ' - ' + quote.author;
         }
@@ -48,6 +48,10 @@ module.exports = {
         return quoteMessage;
     },
 
+    formatAuthor: async (guildManager, interaction, author) => {
+        return await attemptToResolveMentionsToName(guildManager, interaction, author);
+    },
+
     validateAddCommand: async (quote, author, date, interaction) => {
         let reply = 'Your quote has the following problems:\n\n';
         let hasProblem = false;
@@ -65,8 +69,8 @@ module.exports = {
             reply += '- Quotes with links are disallowed.';
             hasProblem = true;
         }
-        if (date && !date.match(/^\d{1,2}[-\/]\d{1,2}[-\/]\d{2,4}$/)) {
-            reply += 'Your provided date has incorrect formatting. Use MM/DD/YYYY or MM-DD-YYYY (e.g. 08/15/2021 or 8-15-21)'
+        if (date && !date.match(/^\d{1,2}[-/]\d{1,2}[-/]\d{2,4}$/)) {
+            reply += 'Your provided date has incorrect formatting. Use MM/DD/YYYY or MM-DD-YYYY (e.g. 08/15/2021 or 8-15-21)';
             hasProblem = true;
         }
         if (hasProblem) {
@@ -99,30 +103,46 @@ module.exports = {
 
 /* When quotes are written to a text file, we want to resolve an ID to a name in the server, if it still exists,
        so that we don't end up writing a representation of the mention (e.g. <@123>) as the author. */
-async function attemptToResolveMentionToName (guildManager, interaction, author) {
+async function attemptToResolveMentionsToName (guildManager, interaction, author) {
     try {
         const guild = await guildManager.fetch(interaction.guildId);
         if (guild) {
-            const entity = await getEntity(guild, author);
-            if (entity) {
-                return entity.nickname
-                    ? '@' + entity.nickname
-                    : (() => {
-                        if (entity.user) {
-                            return '@' + entity.user.username;
-                        } else if (entity.constructor.name === 'Role') {
-                            return '@' + entity.name;
-                        } else {
-                            return '#' + entity.name; // a channel
-                        }
-                    })();
+            const mentions = author.match(constants.MENTION_REGEX);
+            for (const mention of mentions) {
+                let entity;
+                try {
+                    entity = await getEntity(guild, mention);
+                } catch (e) {
+                    author = author.replaceAll(mention, 'Unknown User');
+                    continue;
+                }
+                if (entity) {
+                    const resolved = resolveEntity(entity);
+                    author = author.replaceAll(mention, resolved);
+                } else {
+                    author = author.replaceAll(mention, 'Unknown User');
+                }
             }
         }
-        return 'User not found';
+        return author;
     } catch (e) {
         console.error(e);
-        return 'User not found';
+        return 'Unknown User(s)';
     }
+}
+
+function resolveEntity (entity) {
+    return entity.nickname
+        ? '@' + entity.nickname
+        : (() => {
+            if (entity.user) {
+                return '@' + entity.user.username;
+            } else if (entity.constructor.name === 'Role') {
+                return '@' + entity.name;
+            } else {
+                return '#' + entity.name; // a channel
+            }
+        })();
 }
 
 async function getEntity (guild, author) {

--- a/spec/interaction-handlers-spec.js
+++ b/spec/interaction-handlers-spec.js
@@ -2,6 +2,7 @@ const interactionHandlers = require('../modules/interaction-handlers.js');
 const queries = require('../database/queries.js');
 const responseMessages = require('../modules/response-messages.js');
 const utilities = require('../modules/utilities.js');
+const constants = require('../modules/constants.js');
 
 describe('interaction handlers', () => {
     describe('#addHandler', () => {
@@ -45,7 +46,7 @@ describe('interaction handlers', () => {
 
             await interactionHandlers.addHandler(interaction);
 
-            expect(queries.addQuote).toHaveBeenCalledWith('quote', 'author', '123');
+            expect(queries.addQuote).toHaveBeenCalledWith('quote', 'author', '123', undefined);
             expect(interaction.reply).toHaveBeenCalledWith('Added the following:\n\n_"test"_ - jane doe');
         });
 
@@ -128,6 +129,111 @@ describe('interaction handlers', () => {
 
             expect(queries.getQuotesFromAuthor).toHaveBeenCalledWith('jane', '123');
             expect(interaction.reply).toHaveBeenCalled();
+        });
+    });
+
+    describe('#authorsHandler', () => {
+        let interaction;
+
+        beforeAll(() => {
+            interaction = {
+                options: {
+                    getString: (string) => {
+                        if (string === 'author') {
+                            return null;
+                        }
+                    }
+                },
+                deferReply: async () => { this.deferred = true; },
+                guildId: '123',
+                followUp: async (arg) => {}
+            };
+
+            spyOn(interaction, 'deferReply');
+            spyOn(interaction, 'followUp');
+        });
+
+        it('should follow up with a list of authors separated by bullets', async () => {
+            spyOn(queries, 'fetchUniqueAuthors').and.returnValue([
+                {
+                    author: 'jack'
+                },
+                {
+                    author: 'jane'
+                }
+            ]);
+
+            await interactionHandlers.authorsHandler(interaction);
+
+            expect(queries.fetchUniqueAuthors).toHaveBeenCalledWith('123');
+            expect(interaction.followUp).toHaveBeenCalledWith('Here are all the different authors, separated by ' +
+                'bullet points: \n\n' + 'jack' + constants.AUTHOR_SEPARATOR + 'jane');
+        });
+
+        it('should attach a file if the authors message would be too long', async () => {
+            spyOn(queries, 'fetchUniqueAuthors').and.returnValue([
+                {
+                    author: 'a'.repeat(500)
+                },
+                {
+                    author: 'b'.repeat(500)
+                },
+                {
+                    author: 'c'.repeat(500)
+                },
+                {
+                    author: 'd'.repeat(500)
+                }
+            ]);
+
+            await interactionHandlers.authorsHandler(interaction);
+
+            expect(queries.fetchUniqueAuthors).toHaveBeenCalledWith('123');
+            expect(interaction.followUp).toHaveBeenCalledWith(jasmine.objectContaining(
+                {
+                    content: 'Here are all the different authors. There are a lot of them, so I put them in the attached text file.'
+                }
+            ));
+        });
+
+        it('should attach a file if the authors message would be too long, formatting authors if necessary', async () => {
+            spyOn(queries, 'fetchUniqueAuthors').and.returnValue([
+                {
+                    author: 'a'.repeat(2000)
+                },
+                {
+                    author: '<@121212121212121212>'
+                },
+                {
+                    author: 'myself and <@121212121212121212>'
+                },
+                {
+                    author: '<#121212121212121212> and myself and <@121212121212121212> and <@&121212121212121212>'
+                },
+                {
+                    author: '@myself'
+                },
+                {
+                    author: '<343434343434>'
+                }
+            ]);
+            spyOn(utilities, 'formatAuthor').and.callFake(async (guildManager, interaction, author) => {
+                return await author;
+            });
+
+            await interactionHandlers.authorsHandler(interaction, { });
+
+            expect(queries.fetchUniqueAuthors).toHaveBeenCalledWith('123');
+            expect(utilities.formatAuthor).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), '<@121212121212121212>');
+            expect(utilities.formatAuthor).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), 'myself and <@121212121212121212>');
+            expect(utilities.formatAuthor).toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), '<#121212121212121212> and myself and <@121212121212121212> and <@&121212121212121212>');
+            expect(utilities.formatAuthor).not.toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), '@myself');
+            expect(utilities.formatAuthor).not.toHaveBeenCalledWith(jasmine.anything(), jasmine.anything(), '<343434343434>');
+            expect(interaction.followUp).toHaveBeenCalledWith(jasmine.objectContaining(
+                {
+                    content: 'Here are all the different authors. There are a lot of them, so I put them in the attached text file.'
+                }
+            ));
         });
     });
 });


### PR DESCRIPTION
There was a bug where the /authors reply would be larger than discords max message length. In this case, we write it to a text file. When we do this, we must resolve mentions and such to their nicknames if possible. In doing that, we fixed another bug where we were only considering authors that were a single mention. 