### PR TITLE
remove italics from quote formatting

### DIFF
--- a/modules/interaction-handlers.js
+++ b/modules/interaction-handlers.js
@@ -56,7 +56,6 @@ module.exports = {
                     quote,
                     true,
                     false,
-                    false,
                     true,
                     guildManager,
                     interaction

--- a/modules/utilities.js
+++ b/modules/utilities.js
@@ -6,7 +6,6 @@ module.exports = {
         quote,
         includeDate = true,
         includeIdentifier = false,
-        includeMarkdown = true,
         toFile = false,
         guildManager = null,
         interaction = null
@@ -21,10 +20,6 @@ module.exports = {
 
         if (!quoteCharacters.includes(quoteMessage.charAt(quoteMessage.length - 1))) {
             quoteMessage = quoteMessage + '"';
-        }
-
-        if (includeMarkdown) {
-            quoteMessage = '_' + quoteMessage + '_';
         }
 
         if (toFile && quote.author.match(constants.MENTION_REGEX)) { // Discord @s are represented as <@UserID>


### PR DESCRIPTION
Figured we shouldn't add any markdown to quotes in the bot's replies, in case it conflicts with any markdown the client has added.