### PR TITLE
Create document object in interaction handler scope

### DIFF
--- a/modules/wordcloud-constructor.js
+++ b/modules/wordcloud-constructor.js
@@ -12,7 +12,7 @@ const CONFIG = {
 
 module.exports = import('d3').then((d3) => {
     return {
-        initialize: (wordsWithOccurrences, size, document) => {
+        initialize: (wordsWithOccurrences, size, nodeDocument) => {
             const wordcloud = cloud();
             CONFIG.COLORS = randomColor({
                 luminosity: 'light',
@@ -30,7 +30,7 @@ module.exports = import('d3').then((d3) => {
                 .padding(CONFIG.WORD_PADDING)
                 .rotate(CONFIG.WORD_ROTATION)
                 .timeInterval(10)
-                .canvas(() => document.createElement('canvas'))
+                .canvas(() => nodeDocument.createElement('canvas'))
                 .fontSize(function (d) {
                     return d.size;
                 });

--- a/modules/wordcloud-constructor.js
+++ b/modules/wordcloud-constructor.js
@@ -12,7 +12,7 @@ const CONFIG = {
 
 module.exports = import('d3').then((d3) => {
     return {
-        initialize: (wordsWithOccurrences, size) => {
+        initialize: (wordsWithOccurrences, size, document) => {
             const wordcloud = cloud();
             CONFIG.COLORS = randomColor({
                 luminosity: 'light',
@@ -30,6 +30,7 @@ module.exports = import('d3').then((d3) => {
                 .padding(CONFIG.WORD_PADDING)
                 .rotate(CONFIG.WORD_ROTATION)
                 .timeInterval(10)
+                .canvas(() => document.createElement('canvas'))
                 .fontSize(function (d) {
                     return d.size;
                 });


### PR DESCRIPTION
We were problematically using a global document variable for the wordcloud command, which had the potential to cause side effects with asynchronous processing. Now we're being a bit less dumb.