### PR TITLE
No longer encrypt the quote column

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@
 
 The bot is written in javascript and makes heavy use of [discord.js](https://discord.js.org/#/), which is a wrapper around the Discord API (view the [developer documentation](https://discord.com/developers/docs/intro)).
 
-I currently host the bot using the [Heroku Cloud Platform](https://heroku.com). The bot speaks to a PostgreSQL instance hosted for free on [ElephantSQL](https://www.elephantsql.com/), where I store quotes from the few servers where the bot operates. The bot's connection to the database is SSL-enabled. The "quotation" column is encrypted.
+I currently host the bot using the [Heroku Cloud Platform](https://heroku.com). The bot speaks to a PostgreSQL instance hosted for free using [Aiven](https://aiven.io/).
 
 # Running your own instance of the bot
 
 Stored quotes are associated with a specific guild, so you can safely add the same instance of the bot to multiple servers. 
 
-For the bot to run, you need to populate 4 environment variables referenced within the code. These are `process.env.CLIENT_ID`, `process.env.DATABASE_URL`, `process.env.TOKEN`, and `process.env.ENCRYPTION_KEY`. Read below for how to obtain these.
+For the bot to run, you need to populate 3 environment variables referenced within the code. These are `process.env.CLIENT_ID`, `process.env.DATABASE_URL`, and `process.env.TOKEN`. Read below for how to obtain these.
 
 1. You'll need to [create a discord application through the developer portal](https://discord.com/developers/applications). Your application will be assigned an "Application ID" (aka client id), which can be referenced in the "General Information" section. This will be the value of `process.env.CLIENT_ID`. 
 
@@ -41,10 +41,8 @@ For the bot to run, you need to populate 4 environment variables referenced with
 
     `postgres://your-username:your-password@your-host:your-port/your-database-name`. 
     
-4. You'll need to populate the database with the appropriate schema. See the "Database Schema" section. 
-
-5. You'll need to set `process.env.ENCRYPTION_KEY` to a very strong password. This is used to encrypt several columns.
-    
+4. You'll need to populate the database with the appropriate schema. See the "Database Schema" section.
+   
 5. You'll need to add the bot to your desired server. Within the "Bot" section of your Discord application, you can create a permissions integer that will be added to the OAuth link for a given bot. I recommend, at minimum, the "Send Messages", "Send Messages in Threads", and "Use Slash Commands" permissions, which produce integer `277025392640`. The link to add the bot would then be the following, with your application ID substituted in:
 
     `https://discord.com/oauth2/authorize?client_id=your-application-id&permissions=277025392640&scope=bot`

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,4 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE EXTENSION IF NOT EXISTS citext;
 
 CREATE COLLATION ci (
@@ -13,5 +12,6 @@ CREATE TABLE quotes(
     author character varying(280) COLLATE ci NOT NULL,
     said_at date NOT NULL,
     guild_id character varying(64) NOT NULL,
-    hash text NOT NULL PRIMARY KEY
+    hash text NOT NULL PRIMARY KEY,
+    created_at timestamp with time zone DEFAULT current_timestamp
 );

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "test": "jasmine",
-    "test:db": "SET NODE_ENV=development && SET DATABASE_URL=<your-database-url> && SET ENCRYPTION_KEY=<your-test-key> && node ./spec/local-database-test.js",
+    "test:db": "SET NODE_ENV=development && SET DATABASE_URL=<your-database-url> && node ./spec/local-database-test.js",
     "start": "NODE_ENV=production && node deploy-commands.js && node main.js",
     "start:dev": "SET NODE_ENV=development && SET DATABASE_URL=<your-url-here> && SET TOKEN=<your-token-here> && SET CLIENT_ID=<your-client-id-here> && node deploy-commands.js && node main.js"
   },

--- a/spec/local-database-test.js
+++ b/spec/local-database-test.js
@@ -13,8 +13,8 @@ queries.addQuote('test', 'jane', '1').then((addResult) => {
     console.log(addResult);
     const addedQuoteId = addResult[0].id;
     verify('quote was added to database', addResult.length > 0);
-    verify('query returned unencrypted quote', addResult.length > 0 && addResult[0].quotation && addResult[0].quotation === 'test');
-    verify('query returned unencrypted author', addResult.length > 0 && addResult[0].author && addResult[0].author === 'jane');
+    verify('query returned added quote', addResult.length > 0 && addResult[0].quotation && addResult[0].quotation === 'test');
+    verify('query returned added author', addResult.length > 0 && addResult[0].author && addResult[0].author === 'jane');
     Promise.all(
         [
             queries.fetchAllQuotes('1'),
@@ -31,11 +31,11 @@ queries.addQuote('test', 'jane', '1').then((addResult) => {
             console.log(deletionResult);
             verify('the quote was deleted', deletionResult.length > 0);
             verify(
-                'deletion returned unencrypted quote',
+                'deletion returned deleted quote',
                 deletionResult.length > 0 && deletionResult[0].quotation && deletionResult[0].quotation === 'test'
             );
             verify(
-                'deletion returned unencrypted author',
+                'deletion returned deleted author',
                 deletionResult.length > 0 && deletionResult[0].author && deletionResult[0].author === 'jane'
             );
             console.log('complete.');


### PR DESCRIPTION
Encrypting this column doesn't provide any value. The data is not sensitive, and the database is only accessed by the bot and myself. As the database and the number of severs using the bot grows, I'd like to sidestep any possible performance issues due to the overhead of encrypting/decrypting the column and the inability to index the column.